### PR TITLE
Improve rate limit tracking

### DIFF
--- a/status/healthMonitor.js
+++ b/status/healthMonitor.js
@@ -6,6 +6,7 @@ import { timeStamp, debugLog, createAgent } from '../utils.js';
 const ALLOWED_DELAY = 30 * 60
 const ALLOWED_ERRORS = 10
 const ERROR_COOLDOWN = 10 * 60
+const RATE_LIMIT_COOLDOWN = 24 * 60 * 60
 const HEALTH_TIMEOUT = 5000
 
 function HealthMonitor() {
@@ -103,23 +104,26 @@ function HealthMonitor() {
     }
     const responseTime = timings?.phases?.total
 
-    let { lastError, lastErrorAt, lastSuccessAt, available, rateLimited } = urlHealth;
+    let { lastError, lastErrorAt, lastSuccessAt, available, rateLimited, rateLimitedAt } = urlHealth;
     let errorCount = urlHealth.errorCount || 0;
     if (error) {
       errorCount++;
       lastError = error.message;
       lastErrorAt = Date.now();
-      rateLimited = rateLimited || (response?.statusCode === 429)
+      if(response?.statusCode === 429){
+        rateLimitedAt = Date.now()
+      }
     } else {
       lastSuccessAt = Date.now();
       if (errorCount > 0) {
         const currentTime = Date.now();
-        const cooldownDate = (currentTime - 1000 * ERROR_COOLDOWN);
+        const cooldownDate = currentTime - 1000 * ERROR_COOLDOWN;
         if (lastErrorAt <= cooldownDate) {
           errorCount = 0;
         }
       }
     }
+    rateLimited = rateLimitedAt && rateLimitedAt > Date.now() - 1000 * RATE_LIMIT_COOLDOWN
 
     let nowAvailable = false;
     if (errorCount <= ALLOWED_ERRORS) {
@@ -141,6 +145,7 @@ function HealthMonitor() {
       lastSuccessAt,
       errorCount,
       rateLimited,
+      rateLimitedAt,
       available: nowAvailable,
       blockHeight: blockHeight,
       blockTime: blockTime,

--- a/status/healthMonitor.js
+++ b/status/healthMonitor.js
@@ -156,7 +156,7 @@ function HealthMonitor() {
 
   function checkHeader(type, data, chainId) {
     let error, blockTime;
-    if (data && type === 'rpc')
+    if (data && ['rpc', 'private-rpc'].includes(type))
       data = data.result;
 
     const header = data.block.header;

--- a/status/healthMonitor.js
+++ b/status/healthMonitor.js
@@ -6,7 +6,7 @@ import { timeStamp, debugLog, createAgent } from '../utils.js';
 const ALLOWED_DELAY = 30 * 60
 const ALLOWED_ERRORS = 10
 const ERROR_COOLDOWN = 10 * 60
-const RATE_LIMIT_COOLDOWN = 24 * 60 * 60
+const RATE_LIMIT_COOLDOWN = 3 * 24 * 60 * 60
 const HEALTH_TIMEOUT = 5000
 
 function HealthMonitor() {


### PR DESCRIPTION
Tracks the last time a rate limit error was seen, and marks the node as rate limited for 24 hours. Previously if a rate limit was seen once, the node was marked as rate limited permanently.