### PR TITLE
fix `APY` calculation for `quicksilver`

### DIFF
--- a/chains/chainMonitor.js
+++ b/chains/chainMonitor.js
@@ -93,16 +93,16 @@ function ChainMonitor() {
         aprParams = await calculateApr(chain, annualProvision, bondedTokens, communityTax, blocksPerYear, actualBlocksPerYear) || {}
       }
       const data = {
-        ...current, 
-        ...authzParams, 
-        ...blockParams, 
-        ...stakingParams, 
+        ...current,
+        ...authzParams,
+        ...blockParams,
+        ...stakingParams,
         ...slashingParams,
-        ...supplyParams, 
-        ...mintParams, 
-        ...distributionParams, 
-        ...provisionParams, 
-        ...aprParams 
+        ...supplyParams,
+        ...mintParams,
+        ...distributionParams,
+        ...provisionParams,
+        ...aprParams
       }
       return _.mapKeys({
         ...data,
@@ -214,9 +214,10 @@ function ChainMonitor() {
             inflation: params.params
           }
         }
+        case 'quicksilver':
         case 'osmosis': {
-          const params = await got.get(restUrl + 'osmosis/mint/v1beta1/params', gotOpts).json();
-          const provision = await got.get(restUrl + 'osmosis/mint/v1beta1/epoch_provisions', gotOpts).json();
+          const params = await got.get(restUrl + path + '/mint/v1beta1/params', gotOpts).json();
+          const provision = await got.get(restUrl + path + '/mint/v1beta1/epoch_provisions', gotOpts).json();
           const dailyProvision = bignumber(provision.epoch_provisions)
           return {
             annualProvision: multiply(dailyProvision, 365.3, params.params.distribution_proportions.staking),
@@ -244,15 +245,6 @@ function ChainMonitor() {
         case 'stargaze': {
           const params = await got.get(restUrl + 'minting/annual-provisions', gotOpts).json();
           return { annualProvision: multiply(params.result, 0.5) }
-        }
-        case 'quicksilver': {
-          const params = await got.get(restUrl + 'quicksilver/mint/v1beta1/params', gotOpts).json();
-          const provision = await got.get(restUrl + 'quicksilver/mint/v1beta1/epoch_provisions', gotOpts).json();
-          const dailyProvision = bignumber(provision.epoch_provisions)
-          return {
-            annualProvision: multiply(dailyProvision, 365.3, params.params.distribution_proportions.staking),
-            mint: params.params
-          }
         }
         default: {
           try {

--- a/chains/chainMonitor.js
+++ b/chains/chainMonitor.js
@@ -245,6 +245,15 @@ function ChainMonitor() {
           const params = await got.get(restUrl + 'minting/annual-provisions', gotOpts).json();
           return { annualProvision: multiply(params.result, 0.5) }
         }
+        case 'quicksilver': {
+          const params = await got.get(restUrl + 'quicksilver/mint/v1beta1/params', gotOpts).json();
+          const provision = await got.get(restUrl + 'quicksilver/mint/v1beta1/epoch_provisions', gotOpts).json();
+          const dailyProvision = bignumber(provision.epoch_provisions)
+          return {
+            annualProvision: multiply(dailyProvision, 365.3, params.params.distribution_proportions.staking),
+            mint: params.params
+          }
+        }
         default: {
           try {
             const params = await got.get(restUrl + 'cosmos/mint/v1beta1/annual_provisions', gotOpts).json();


### PR DESCRIPTION
- `quicksilver` does not use sdk mint module, current calc consider it
- it uses osmosis mint module - have replaced the APR calc
- Not really sure if the changes are exhaustive? please guide through other changes needed (if any)